### PR TITLE
Adding proxy support for pagerDuty client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,25 @@ install:
   - mvn install -P !build-extras -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   - export TRAVIS_COMMIT_DESCRIPTION=`git log -n 1`
 
-script:
-  # The below should be placed in the after_success stage but due to the nature on how travis deals with after_script
-  # exit codes different than 0 would not affect the build result which is not the expectation in this case.
-  - mvn test -P !build-extras -B  || travis_terminate 1;
-  - chmod +x ./travis-ci/before-deploy.sh ./travis-ci/deploy.sh ./travis-ci/cleanup.sh || travis_terminate 1;
-  - ./travis-ci/before-deploy.sh;
-  - ./travis-ci/deploy.sh;
-  - ./travis-ci/cleanup.sh;
+jobs:
+  include:
+    - stage: test
+      script:
+        - mvn test -P !build-extras -B  || travis_terminate 1;
+    - stage: deploy
+      script:
+        # The below should be placed in the after_success stage but due to the nature on how travis deals with after_script
+        # exit codes different than 0 would not affect the build result which is not the expectation in this case.
+        # Set up git user name and tag this commit
+        - chmod +x ./travis-ci/before-deploy.sh ./travis-ci/deploy.sh ./travis-ci/cleanup.sh || travis_terminate 1;
+        - ./travis-ci/before-deploy.sh;
+        - ./travis-ci/deploy.sh;
+        - ./travis-ci/cleanup.sh;
+stages:
+  - name: test
+    if: type = pull_request OR (type = push AND branch = master)
+  - name: deploy
+    if: type = push AND branch = master
 
 cache:
   directories:

--- a/src/main/java/com/github/dikhan/pagerduty/client/events/ApiServiceFactory.java
+++ b/src/main/java/com/github/dikhan/pagerduty/client/events/ApiServiceFactory.java
@@ -1,5 +1,7 @@
 package com.github.dikhan.pagerduty.client.events;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * This class is in charge of producing implementations of ApiService. The default impl can be retrieved
  * by calling {@link ApiServiceFactory#getDefault()} method. In the case where a new impl is preferred, that
@@ -8,12 +10,23 @@ package com.github.dikhan.pagerduty.client.events;
 public class ApiServiceFactory {
 
     private final String eventApi;
+    private final String proxyHost;
+    private final Integer proxyPort;
 
     public ApiServiceFactory(String eventApi) {
+        this(eventApi, null, null);
+    }
+
+    public ApiServiceFactory(String eventApi, String proxyHost, Integer proxyPort) {
         this.eventApi = eventApi;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
     }
 
     public ApiService getDefault() {
+        if (!StringUtils.isEmpty(proxyHost) && proxyPort!= null) {
+            return new HttpApiServiceImpl(eventApi, proxyHost, proxyPort);
+        }
         return new HttpApiServiceImpl(eventApi);
     }
 

--- a/src/main/java/com/github/dikhan/pagerduty/client/events/HttpApiServiceImpl.java
+++ b/src/main/java/com/github/dikhan/pagerduty/client/events/HttpApiServiceImpl.java
@@ -10,6 +10,7 @@ import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.HttpRequestWithBody;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +28,18 @@ public class HttpApiServiceImpl implements ApiService {
         initUnirest();
     }
 
+    public HttpApiServiceImpl(String eventApi, String proxyHost, Integer proxyPort) {
+        this.eventApi = eventApi;
+        initUnirestWithProxy(proxyHost, proxyPort);
+    }
+
     private void initUnirest() {
         Unirest.setObjectMapper(new JacksonObjectMapper());
+    }
+
+    private void initUnirestWithProxy(String proxyHost, Integer proxyPort) {
+        initUnirest();
+        Unirest.setProxy(new HttpHost(proxyHost, proxyPort));
     }
 
     public EventResult notifyEvent(Incident incident) throws NotifyEventException {

--- a/src/main/java/com/github/dikhan/pagerduty/client/events/PagerDutyEventsClient.java
+++ b/src/main/java/com/github/dikhan/pagerduty/client/events/PagerDutyEventsClient.java
@@ -19,7 +19,9 @@ public class PagerDutyEventsClient {
 
     protected PagerDutyEventsClient(PagerDutyClientBuilder pagerDutyClientBuilder) {
         String eventApi = pagerDutyClientBuilder.getEventApi();
-        this.httpApiServiceImpl = new ApiServiceFactory(eventApi).getDefault();
+        String proxyHost = pagerDutyClientBuilder.getProxyHost();
+        Integer proxyPort = pagerDutyClientBuilder.getProxyPort();
+        this.httpApiServiceImpl = new ApiServiceFactory(eventApi, proxyHost, proxyPort).getDefault();
     }
 
     public static void main(String[] args) throws NotifyEventException {
@@ -92,6 +94,17 @@ public class PagerDutyEventsClient {
         return new PagerDutyClientBuilder().withEventApi(eventApi).build();
     }
 
+    /**
+     * Simple helper method to newBuilder a PagerDuty client with specific proxy configuration
+     *
+     * @param proxyHost Host of the configured proxy used by the PagerDuty client
+     * @param proxyPort Port of the configured proxy used by the PagerDuty client
+     * @return PagerDuty client which allows interaction with the service via API calls
+     */
+    public static PagerDutyEventsClient create(String proxyHost, Integer proxyPort) {
+        return new PagerDutyClientBuilder().withProxyHost(proxyHost).withProxyPort(proxyPort).build();
+    }
+
     public EventResult trigger(TriggerIncident incident) throws NotifyEventException {
         EventResult eventResult = sendEvent(incident);
         return eventResult;
@@ -119,11 +132,24 @@ public class PagerDutyEventsClient {
 
         private String eventApi;
 
+        private String proxyHost;
+        private Integer proxyPort;
+
         public PagerDutyClientBuilder() {
         }
 
         public PagerDutyClientBuilder withEventApi(String eventApi) {
             this.eventApi = eventApi;
+            return this;
+        }
+
+        public PagerDutyClientBuilder withProxyHost(String proxyHost) {
+            this.proxyHost = proxyHost;
+            return this;
+        }
+
+        public PagerDutyClientBuilder withProxyPort(Integer proxyPort) {
+            this.proxyPort = proxyPort;
             return this;
         }
 
@@ -136,6 +162,14 @@ public class PagerDutyEventsClient {
 
         public String getEventApi() {
             return eventApi;
+        }
+
+        public String getProxyHost() {
+            return proxyHost;
+        }
+
+        public Integer getProxyPort() {
+            return proxyPort;
         }
     }
 }

--- a/src/test/java/com/github/dikhan/pagerduty/client/events/ApiServiceFactoryTest.java
+++ b/src/test/java/com/github/dikhan/pagerduty/client/events/ApiServiceFactoryTest.java
@@ -1,5 +1,6 @@
 package com.github.dikhan.pagerduty.client.events;
 
+import com.mashape.unirest.http.Unirest;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,5 +29,7 @@ public class ApiServiceFactoryTest {
         HttpApiServiceImpl httpApiService = new HttpApiServiceImpl(eventApi, proxyHost, proxyPort);
         assertThat(apiService).isExactlyInstanceOf(HttpApiServiceImpl.class);
         assertThat(apiService).isEqualTo(httpApiService);
+        // reset uni rest settings
+        Unirest.setProxy(null);
     }
 }

--- a/src/test/java/com/github/dikhan/pagerduty/client/events/ApiServiceFactoryTest.java
+++ b/src/test/java/com/github/dikhan/pagerduty/client/events/ApiServiceFactoryTest.java
@@ -16,4 +16,17 @@ public class ApiServiceFactoryTest {
         assertThat(apiService).isExactlyInstanceOf(HttpApiServiceImpl.class);
         assertThat(apiService).isEqualTo(httpApiService);
     }
+
+    @Test
+    public void apiServiceFactoryWithProxyParamsProducesRightDefaultApiServiceImpl() {
+        String eventApi = "eventApi";
+        String proxyHost = "localhost";
+        Integer proxyPort = 8080;
+        ApiServiceFactory apiServiceFactory = new ApiServiceFactory(eventApi, proxyHost, proxyPort);
+
+        ApiService apiService = apiServiceFactory.getDefault();
+        HttpApiServiceImpl httpApiService = new HttpApiServiceImpl(eventApi, proxyHost, proxyPort);
+        assertThat(apiService).isExactlyInstanceOf(HttpApiServiceImpl.class);
+        assertThat(apiService).isEqualTo(httpApiService);
+    }
 }


### PR DESCRIPTION
Hey folks,

I'm trying to use this awesome pagerDuty client behind a corporate proxy and I'm having the same issue as described here: https://github.com/dikhan/pagerduty-client/issues/12

This PR introduces the ability to specify a proxy configuration when creating a PagerDutyEvents client. An alternative solution I've considered was to make the Unirest HTTP client automatically pick up system proxy env variables, but that might impact people already using this lib. Also, there are multiple env variables used for setting proxies since there is some convention around them, but not a standard (e.g. $http_proxy, $http.proxyHost)

Please take a look when you have a chance, I'm happy to address any of your comments here.

Thanks,
Bogdan.